### PR TITLE
Added support for release variant

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,8 @@ buildscript {
     }
   }
 
+  ext.chuckerEnabled = project.properties["CHUCKER_ENABLED"] ?: "false"
+
   repositories {
     mavenCentral()
   }
@@ -88,6 +90,10 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 
   implementation("com.facebook.react:react-android")
-  debugImplementation "com.github.chuckerteam.chucker:library:4.0.0"
-  releaseImplementation "com.github.chuckerteam.chucker:library-no-op:4.0.0"
+  if (chuckerEnabled.toBoolean()) {
+    implementation "com.github.chuckerteam.chucker:library:4.0.0"
+  } else {
+    debugImplementation "com.github.chuckerteam.chucker:library:4.0.0"
+    releaseImplementation "com.github.chuckerteam.chucker:library-no-op:4.0.0"
+  }
 }

--- a/plugin/src/with-expo-chucker.ts
+++ b/plugin/src/with-expo-chucker.ts
@@ -3,6 +3,7 @@ import {
   ConfigPlugin,
   withAndroidManifest,
   withPlugins,
+  withGradleProperties,
 } from "@expo/config-plugins";
 import { addPermission } from "@expo/config-plugins/build/android/Permissions";
 
@@ -38,12 +39,24 @@ const withPermission: ConfigPlugin = (config) => {
   });
 };
 
-export const withExpoChucker: ConfigPlugin<{ enabled?: boolean }> = (
+const withFlagGradleProperties: ConfigPlugin<{ enabled?: boolean }> = (config, { enabled = false }) => {
+  return withGradleProperties(config, (config) => {
+    config.modResults.push({
+      type: "property",
+      key: "CHUCKER_ENABLED",
+      value: enabled ? "true" : "false",
+    });
+    return config;
+  });
+};
+
+export const withExpoChucker: ConfigPlugin<{ enabled?: boolean; }> = (
   config,
   { enabled } = { enabled: true }
 ) => {
   return withPlugins(config, [
     [withFlagMetadataMainApplication, { enabled }],
+    [withFlagGradleProperties, { enabled }],
     withPermission,
   ]);
 };


### PR DESCRIPTION
Motivation: For our case chucker is required for certain release variant

Currently, chucker is enabled only in debug variant, this PR added support to the release variant too.