### PR TITLE
feat: v1.4.1 — fix multipart body stream + add upload test example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-04-20
+
+### Fixed
+
+- Fix: Prevent multipart body stream consumption that caused crashed/empty request body when uploading files (by [@seif-rashad](https://github.com/seif-rashad))
+
+### Added
+
+- Add UploadTest component in example app for multipart upload testing
+
 ## [1.4.0] - 2026-04-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ No JavaScript API is exposed — the module initializes itself on app startup vi
 
 | expo-chucker | expo     | chucker |
 | :----------: | :------: | :-----: |
+|    1.4.1     | 53,54,55 |  4.2.0  |
 |    1.4.0     | 53,54,55 |  4.2.0  |
 |    1.3.0     | 52       |  4.1.0  |
 |    0.1.5     | 51       |  4.0.0  |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = "com.chucker"
-version = "1.4.0"
+version = "1.4.1"
 
 def getVersionCodeFromVersion(String version) {
     def (major, minor, patch) = version.tokenize('.')
@@ -39,8 +39,8 @@ if (useManagedAndroidSdkVersions) {
 android {
   namespace "com.chucker"
   defaultConfig {
-    versionCode getVersionCodeFromVersion("1.4.0")
-    versionName "1.4.0"
+    versionCode getVersionCodeFromVersion("1.4.1")
+    versionName "1.4.1"
   }
   lintOptions {
     abortOnError false

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,5 +1,6 @@
 import * as Notifications from "expo-notifications";
 import { useEffect, useState, useTransition } from "react";
+import { UploadTest } from "./UploadTest";
 import { ActivityIndicator, Button, FlatList, StyleSheet, Text, View } from "react-native";
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
   return (
     <View style={styles.container}>
       <Button title="Do HTTP Request" onPress={handlePress} disabled={isPending} />
+      <UploadTest />
       {isPending && <ActivityIndicator />}
       <FlatList
         data={users}

--- a/example/UploadTest.tsx
+++ b/example/UploadTest.tsx
@@ -1,0 +1,107 @@
+import { useState, useTransition } from "react";
+import { ActivityIndicator, Button, StyleSheet, Text, View } from "react-native";
+
+type UploadStatus = "idle" | "success" | "error";
+
+export function UploadTest() {
+  const [simpleStatus, setSimpleStatus] = useState<UploadStatus>("idle");
+  const [formStatus, setFormStatus] = useState<UploadStatus>("idle");
+  const [isSimplePending, startSimpleTransition] = useTransition();
+  const [isFormPending, startFormTransition] = useTransition();
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Button
+          title="Upload File (simple)"
+          onPress={() => startSimpleTransition(() => uploadFakeFile().then(setSimpleStatus))}
+          disabled={isSimplePending}
+        />
+        {isSimplePending && <ActivityIndicator />}
+        {simpleStatus === "success" && <Text style={styles.success}>OK</Text>}
+        {simpleStatus === "error" && <Text style={styles.error}>Error</Text>}
+      </View>
+
+      <View style={styles.row}>
+        <Button
+          title="Upload File + Form Data"
+          onPress={() => startFormTransition(() => uploadWithFormData().then(setFormStatus))}
+          disabled={isFormPending}
+        />
+        {isFormPending && <ActivityIndicator />}
+        {formStatus === "success" && <Text style={styles.success}>OK</Text>}
+        {formStatus === "error" && <Text style={styles.error}>Error</Text>}
+      </View>
+    </View>
+  );
+}
+
+async function uploadFakeFile(): Promise<UploadStatus> {
+  try {
+    const blob = new Blob(["fake-binary-content-for-testing"], { type: "image/png" });
+
+    const formData = new FormData();
+    formData.append("file", blob as any, "test-image.png");
+    formData.append("description", "multipart upload test");
+
+    const response = await fetch("https://postman-echo.com/post", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    return "success";
+  } catch (e) {
+    console.error("Upload error:", e);
+    return "error";
+  }
+}
+
+async function uploadWithFormData(): Promise<UploadStatus> {
+  try {
+    const blob = new Blob(["fake-binary-content-for-testing"], { type: "image/png" });
+
+    const formData = new FormData();
+    formData.append("file", blob as any, "profile-photo.png");
+    formData.append("name", "John Doe");
+    formData.append("email", "john@example.com");
+    formData.append("age", "28");
+    formData.append("description", "User profile photo upload");
+
+    const response = await fetch("https://postman-echo.com/post", {
+      method: "POST",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    return "success";
+  } catch (e) {
+    console.error("Upload error:", e);
+    return "error";
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 8,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  success: {
+    color: "green",
+    fontSize: 13,
+  },
+  error: {
+    color: "red",
+    fontSize: 13,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-chucker",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Android HTTP(S) inspector for Expo — wraps Chucker for network debugging",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
## Summary

- Fix: Prevent multipart body stream consumption that caused crash/empty request body when uploading files (credits: [@seif-rashad](https://github.com/seif-rashad), PR #11)
- Add `UploadTest` component in example app for manual multipart upload testing
- Bump version to 1.4.1

## Changes

- `android/src/main/java/com/chucker/CustomNetworkModule.kt` — use `ChuckerMultipartInterceptor` instead of `ChuckerInterceptor`
- `example/UploadTest.tsx` — new component with two upload buttons for testing
- `package.json` + `android/build.gradle` — bump to 1.4.1
- `CHANGELOG.md` + `README.md` — updated

## Test plan

- [x] App does not crash on multipart POST request
- [x] Form fields visible in Chucker notification
- [x] Regular HTTP request (Do HTTP Request button) still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)